### PR TITLE
Remove Nunjucks previews

### DIFF
--- a/docs/_includes/example.njk
+++ b/docs/_includes/example.njk
@@ -7,7 +7,6 @@
 <div class="app-tabs" data-module="app-tabs">
   <ul class="app-tabs__list" role="tablist">
     <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab" href="#html-default-{{ id }}" role="tab" id="tab_html-default-{{ id }}" aria-controls="html-default-{{ id }}">HTML</a></li>
-    <li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab" href="#nunjucks-default-{{ id }}" role="tab" id="tab_nunjucks-default-{{ id }}" aria-controls="nunjucks-default-{{ id }}">Nunjucks</a></li>
     {% if jsCode %}<li class="app-tabs__list-item" role="presentation"><a class="app-tabs__tab" href="#js-default-{{ id }}" role="tab" id="tab_j-default-{{ id }}" aria-controls="js-default-{{ id }}">JavaScript</a></li>{% endif %}
   </ul>
 
@@ -16,33 +15,6 @@
 ```html
 {{ htmlCode | safe }}
 ```
-  </div>
-
-  <div class="app-tabs__panel app-tabs__panel--hidden" id="nunjucks-default-{{ id }}" role="tabpanel" aria-labelledby="tab_nunjucks-default-{{ id }}">
-
-{% if arguments %}
-  <details class="govuk-details govuk-!-padding-3" data-module="govuk-details">
-    <summary class="govuk-details__summary">
-      <span class="govuk-details__summary-text">
-        Nunjucks macro options
-      </span>
-    </summary>
-    <div class="govuk-details__text">
-
-{% include "./arguments/" + arguments + ".md" %}
-
-    </div>
-  </details>
-{% endif %}
-
-  <div data-module="app-copy" style="position:relative;">
-
-```jinja
-{{ nunjucksCode | safe }}
-```
-
-  </div>
-
   </div>
 
 {% if jsCode %}


### PR DESCRIPTION
Removes the Nunjuck preview panel for components and patterns, since we're only using vanilla HTML in this design system.